### PR TITLE
pillow 9.0.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ set ZLIB_ROOT=%LIBRARY_PREFIX%
 set TIFF_ROOT=%LIBRARY_PREFIX%
 set FREETYPE_ROOT=%LIBRARY_PREFIX%
 :: set LCMS_ROOT=%LIBRARY_PREFIX%
+set WEBP_ROOT=%LIBRARY_PREFIX%
 
 
 %PYTHON% -m pip install . --no-deps --ignore-installed --no-cache-dir --global-option="build_ext" --global-option="--enable-webp" -vvv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,5 +7,6 @@ export ZLIB_ROOT=$PREFIX
 export TIFF_ROOT=$PREFIX
 export FREETYPE_ROOT=$PREFIX
 export LCMS_ROOT=$PREFIX
+export WEBP_ROOT=$PREFIX
 
 $PYTHON -m pip install . --no-deps --ignore-installed --no-cache-dir --global-option="build_ext" --global-option="--enable-webp" -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     - libtiff
     - freetype
     - tk
-    - libwebp-base
+    - libwebp-base  # [non s390x]
+    - libwebp  # [s390x]
   run:
     - python
     - jpeg
@@ -48,7 +49,8 @@ requirements:
     - freetype
     - libtiff
     - tk
-    - libwebp-base >=0.3.0
+    - libwebp-base >=0.3.0  # [non s390x]
+    - libwebp >=0.3.0  # [s390x]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "pillow" %}
 {% set version = "9.0.1" %}
 
 package:
-  name: pillow
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/P/Pillow/Pillow-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Pillow-{{ version }}.tar.gz
   sha256: 6c8bc8238a7dfdaf7a75f5ec5a663f4173f8c367e5a39f87e720495e1eed75fa
   patches:                  # [unix]
     - disable_detect.patch  # [unix]
@@ -46,7 +47,6 @@ requirements:
     - zlib
     - freetype
     - libtiff
-    - olefile
     - tk
     - libwebp >=0.3.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,16 +40,15 @@ requirements:
     - libtiff
     - freetype
     - tk
-    - libwebp >=0.3.0
+    - libwebp-base
   run:
     - python
     - jpeg
     - zlib
     - freetype
     - libtiff
-    - olefile
     - tk
-    - libwebp >=0.3.0
+    - libwebp-base >=0.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - libtiff
     - freetype
     - tk
-    - libwebp-base  # [non s390x]
+    - libwebp-base  # [not s390x]
     - libwebp  # [s390x]
   run:
     - python
@@ -49,7 +49,7 @@ requirements:
     - freetype
     - libtiff
     - tk
-    - libwebp-base >=0.3.0  # [non s390x]
+    - libwebp-base >=0.3.0  # [not s390x]
     - libwebp >=0.3.0  # [s390x]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     - libtiff
     - freetype
     - tk
-    - libweb
+    - libwebp
+    - libwebp-base
   run:
     - python
     - jpeg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - zlib
     - freetype
     - libtiff
+    - olefile
     - tk
     - libwebp >=0.3.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - jpeg
     - libtiff
     - libwebp >=0.3.0
+    - libwebp-base  # [osx and arm64]
     - tk
     - zlib
 
@@ -57,7 +58,6 @@ test:
     - PIL.ImageCms  # [not win]
   requires:
     - pip
-    - libwebp-base  # [osx and arm64]
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ test:
     - PIL.ImageCms  # [not win]
   requires:
     - pip
+    - libwebp-base  # [osx and arm64]
   commands:
     - pip check
 
@@ -69,7 +70,7 @@ about:
   description: |
     Pillow is the friendly PIL fork. PIL is the Python Imaging Library,
     adds image processing capabilities to your Python interpreter.
-  doc_url: http://pillow.readthedocs.io/en/4.2.x/
+  doc_url: https://pillow.readthedocs.io/en/4.2.x/
   doc_source_url: https://github.com/python-pillow/Pillow/blob/4.2.x/docs/index.rst
   dev_url: https://github.com/python-pillow/Pillow
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,9 +57,6 @@ test:
     - PIL.ImageCms  # [not win]
   requires:
     - pip
-    - requests
-    - aiohttp
-    - fsspec
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,7 @@ requirements:
     - libtiff
     - freetype
     - tk
-    - libwebp-base  # [not s390x]
-    - libwebp  # [s390x]
+    - libweb
   run:
     - python
     - jpeg
@@ -49,8 +48,8 @@ requirements:
     - freetype
     - libtiff
     - tk
-    - libwebp-base >=0.3.0  # [not s390x]
-    - libwebp >=0.3.0  # [s390x]
+    - libwebp-base >=0.3.0
+    - libwebp >=0.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,11 +55,6 @@ test:
     - PIL
     - PIL.Image
     - PIL.ImageCms  # [not win]
-    - PIL._imaging
-    - PIL._imagingft
-    - PIL._imagingmath
-    - PIL._imagingmorph
-    - PIL._imagingtk  # [linux and not (arm or ppc64le or aarch64)]
   requires:
     - pip
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     # Required by default
     - zlib
     - jpeg
-    # Optional dependencies 
+    # Optional dependencies
     # (also can be incuded libwebp, libimagequant, libraqm, 
     # libxcb, openjpeg (it causes build errors on win32),
     # see https://pillow.readthedocs.io/en/latest/installation.html#external-libraries)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.4.0" %}
+{% set version = "9.0.1" %}
 
 package:
   name: pillow
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/P/Pillow/Pillow-{{ version }}.tar.gz
-  sha256: b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed
+  sha256: 6c8bc8238a7dfdaf7a75f5ec5a663f4173f8c367e5a39f87e720495e1eed75fa
   patches:                  # [unix]
     - disable_detect.patch  # [unix]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - freetype
     - tk
     - libwebp
-    - libwebp-base
   run:
     - python
     - jpeg
@@ -49,7 +48,6 @@ requirements:
     - freetype
     - libtiff
     - tk
-    - libwebp-base >=0.3.0
     - libwebp >=0.3.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,25 +30,25 @@ requirements:
     - setuptools
     - wheel
     # Required by default
-    - zlib
     - jpeg
+    - zlib
     # Optional dependencies
     # (also can be incuded libwebp, libimagequant, libraqm, 
     # libxcb, openjpeg (it causes build errors on win32),
     # see https://pillow.readthedocs.io/en/latest/installation.html#external-libraries)
+    - freetype
     - lcms2  # [not win]
     - libtiff
-    - freetype
-    - tk
     - libwebp
+    - tk
   run:
     - python
-    - jpeg
-    - zlib
     - freetype
+    - jpeg
     - libtiff
-    - tk
     - libwebp >=0.3.0
+    - tk
+    - zlib
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<37]
   ignore_run_exports:
     - tk
     - jpeg


### PR DESCRIPTION
Update pillow to 9.0.1

Version change: bump version number from 8.4.0 to 9.0.1
Bug Tracker: new open issues https://github.com/python-pillow/Pillow/issues
License file: https://github.com/python-pillow/Pillow/blob/master/LICENSE
Upstream Changelog: https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
Upstream setup: 
- https://github.com/python-pillow/Pillow/blob/9.0.1/setup.cfg, 
- https://github.com/python-pillow/Pillow/blob/9.0.1/setup.py
- https://pillow.readthedocs.io/en/latest/installation.html

The package pillow is mentioned inside the packages:
bokeh | caffe | caffe-gpu | constructor | datashader | fuel | glue-core | imagecodecs | imagehash | imageio | imgaug | libtiff | matplotlib | neon |  pims | quiver_engine | reportlab | scikit-image | torchvision |

Actions:
1. Update buil`d.sh` and b`ld.bat`
2. Skip `py<37`
3. Reorder host and run dependencies
4. Add libw`ebp-base` for `osx-arm64`
5. Remove private packages from `test/imports`
6. Remove unused packages from `test/require`s. NOTE: we should add python 3.10 support for aiohttp
7. Fix doc url with HTTPS

Result:
- all-failed