### PR TITLE
pillow 9.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pillow" %}
-{% set version = "9.0.1" %}
+{% set version = "9.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Pillow-{{ version }}.tar.gz
-  sha256: 6c8bc8238a7dfdaf7a75f5ec5a663f4173f8c367e5a39f87e720495e1eed75fa
+  sha256: 75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04
   patches:                  # [unix]
     - disable_detect.patch  # [unix]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
 test:
   imports:
     - PIL
-    - PIL.Image
+    - PIL.Image     # [not win]
     - PIL.ImageCms  # [not win]
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,10 @@ build:
   ignore_run_exports:
     - tk
     - jpeg
-    - libwebp  # [win]
-    - zlip  # [win and (py==37 or py==38)]
-    - freetype  # [win and (py==37 or py==38)]
-    - libtiff  # [win and (py==37 or py==38)]
+    - freetype  # [win]
+    - libtiff   # [win]
+    - libwebp   # [win]
+    - zlip      # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
     - freetype  # [win]
     - libtiff   # [win]
     - libwebp   # [win]
-    - zlip      # [win]
+    - zlib      # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,9 @@ build:
     - tk
     - jpeg
     - libwebp  # [win]
+    - zlip  # [win and (py==37 or py==38)]
+    - freetype  # [win and (py==37 or py==38)]
+    - libtiff  # [win and (py==37 or py==38)]
 
 requirements:
   build:


### PR DESCRIPTION
Update to 9.2.0 to fix CVE-2022-30595

Bug Tracker: new open issues https://github.com/python-pillow/Pillow/issues
License file: https://github.com/python-pillow/Pillow/blob/master/LICENSE
Upstream Changelog: https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
Upstream setup:

- https://github.com/python-pillow/Pillow/blob/9.2.0/setup.cfg,
- https://github.com/python-pillow/Pillow/blob/9.2.0/setup.py
- https://pillow.readthedocs.io/en/latest/installation.html

Actions:
1.  Add to `ignore_run_exports`:
```
    - freetype  # [win]
    - libtiff   # [win]
    - libwebp   # [win]
    - zlib      # [win]
```