### PR TITLE
[PKG-2296] pillow 10.0.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,7 @@ set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 set LIBRARY_DIRS=%LIBRARY_BIN%;%LIBRARY_LIB%
 
 set JPEG_ROOT=%LIBRARY_PREFIX%
-:: set JPEG2K_ROOT=%LIBRARY_PREFIX%
+set JPEG2K_ROOT=%LIBRARY_PREFIX%
 set ZLIB_ROOT=%LIBRARY_PREFIX%
 :: set IMAGEQUANT_ROOT=%LIBRARY_PREFIX%
 set TIFF_ROOT=%LIBRARY_PREFIX%
@@ -12,5 +12,5 @@ set FREETYPE_ROOT=%LIBRARY_PREFIX%
 set WEBP_ROOT=%LIBRARY_PREFIX%
 
 
-%PYTHON% -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir --global-option="build_ext" --global-option="--enable-webp" -vvv
+%PYTHON% -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir --global-option="build_ext" --global-option="--enable-webp" --global-option="--enable-jpeg2000" -vv
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export JPEG_ROOT=$PREFIX
-# export JPEG2K_ROOT=None
+export JPEG2K_ROOT=$PREFIX
 export ZLIB_ROOT=$PREFIX
 # export IMAGEQUANT_ROOT=None
 export TIFF_ROOT=$PREFIX
@@ -9,4 +9,4 @@ export FREETYPE_ROOT=$PREFIX
 export LCMS_ROOT=$PREFIX
 export WEBP_ROOT=$PREFIX
 
-$PYTHON -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir --global-option="build_ext" --global-option="--enable-webp" -vvv
+$PYTHON -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir --global-option="build_ext" --global-option="--enable-webp" --global-option="--enable-jpeg2000" -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,13 +28,14 @@ requirements:
     - jpeg 9e
     - zlib 1.2.13
     # Optional dependencies
-    # (also can be incuded libwebp, libimagequant, libraqm, 
+    # (also can be incuded libwebp, libimagequant, libraqm,
     # libxcb, openjpeg (it causes build errors on win32),
     # see https://pillow.readthedocs.io/en/latest/installation.html#external-libraries)
     - freetype 2.10.4
     - lcms2 2.12       # [not win]
     - libtiff 4.2.0
     - libwebp 1.3.2
+    - openjpeg
     - tk 8.6.12
   run:
     - python
@@ -42,6 +43,7 @@ requirements:
     - jpeg >=9e,<10a
     - libtiff >=4.2.0,<5.0a0
     - libwebp >=1.3.2,<2.0a0
+    - openjpeg >=2.3.0,<3.0a0
     - tk >=8.6.12,<8.7.0a0
     - zlib >=1.2.13,<1.3.0a0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pillow" %}
-{% set version = "9.4.0" %}
+{% set version = "10.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Pillow-{{ version }}.tar.gz
-  sha256: a1c2d7780448eb93fbcc3789bf3916aa5720d942e37945f4056680317f1cd23e
+  sha256: d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d
   patches:                  # [unix]
     - disable_detect.patch  # [unix]
 
 build:
-  number: 1
-  skip: true  # [py<37]
+  number: 0
 
 requirements:
   build:
@@ -23,13 +22,7 @@ requirements:
   host:
     - python
     - pip
-    # 2022/7/14: The issue was observed with 'import PIL.Image' in v9.2.0:
-    # Additional double quotes for Core version: "9.2.0" on win-64 for python 3.7 and python 3.8.
-    # The last version of pillow we built (v9.0.1) was built using conda-build-3.21.7, 
-    # Looking at the conda-build changelog for v3.21.9, it was noticed some changes to support the new setuptools >=60.0
-    # 2023/2/23: It persists in 9.4.0. Check if the issue persists in the next releases 
-    - setuptools <60  # [win and (py==37 or py==38)]
-    - setuptools      # [not (win and (py==37 or py==38))]
+    - setuptools
     - wheel
     # Required by default
     - jpeg 9e
@@ -64,8 +57,8 @@ test:
 
 about:
   home: https://pillow.readthedocs.io
-  license: LicenseRef-PIL
-  license_family: Other 
+  license: HPND
+  license_family: Other
   license_file: LICENSE
   summary: Pillow is the friendly PIL fork by Alex Clark and Contributors
   description: |


### PR DESCRIPTION
**The upstream data:**
Github releases:  https://github.com/python-pillow/Pillow/releases
[Diff between the latest and previous upstream releases](https://github.com/python-pillow/Pillow/compare/9.4.0...10.0.1)
Changelog: 
- https://github.com/python-pillow/Pillow/blob/10.0.1/CHANGES.rst
- https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html
Requirements:
 * https://github.com/python-pillow/Pillow/blob/10.0.1/pyproject.toml
 * setup.cfg:  https://github.com/python-pillow/Pillow/blob/10.0.1/setup.cfg
 * setup.py:  https://github.com/python-pillow/Pillow/blob/10.0.1/setup.py
 * https://pillow.readthedocs.io/en/latest/installation.html

**_Actions:_**

1. Reset build number to `0`
2. Add `openjpeg` to enable **jpeg2000** support
3. Remove pinning for `setuptools` on `win`
4. Fix `license` name, see https://github.com/python-pillow/Pillow/blob/e34d346f10c0b1c814661e662a3e0c1ef084cf1c/LICENSE#L10C52-L10C56

Notes:
- from logs:
```
--------------------------------------------------------------------
  --- JPEG support available
  --- OPENJPEG (JPEG2000) support available (2.3)
  --- ZLIB (PNG/ZIP) support available
  *** LIBIMAGEQUANT support not available
  --- LIBTIFF support available
  --- FREETYPE2 support available
  *** RAQM (Text shaping) support not available
  --- LITTLECMS2 support available
  --- WEBP support available
  --- WEBPMUX support available
  *** XCB (X protocol) support not available
  --------------------------------------------------------------------
```
