### PR TITLE
pillow 10.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -c "from PIL.Image import core"
 
 about:
   home: https://pillow.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pillow" %}
-{% set version = "10.3.0" %}
+{% set version = "10.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d
+  sha256: 166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06
 
 build:
   number: 0
@@ -48,6 +48,8 @@ test:
     - PIL
     - PIL.Image
     - PIL.ImageCms  # [not win]
+    # Testing _imaging to prevent an error 'DLL load failed while importing _imaging'
+    - PIL._imaging
   # The upstream Tests/images contains a lot of image files that can be tested by pytest 
   # but then the size of the package will increase significantly (+70Mb).
   # Pillow tests against some images that it cannot keep in-repo


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5184](https://anaconda.atlassian.net/browse/PKG-5184) 
- [Upstream repository](https://github.com/python-pillow/Pillow/blob/10.4.0)
- [Diff between the latest and previous upstream releases](https://github.com/python-pillow/Pillow/compare/10.3.0...10.4.0)
- Changelog: 
  - https://github.com/python-pillow/Pillow/blob/10.4.0/CHANGES.rst
  - https://pillow.readthedocs.io/en/stable/releasenotes/10.4.0.html
  
- Requirements:
  - https://github.com/python-pillow/Pillow/blob/10.4.0/pyproject.toml
  - https://github.com/python-pillow/Pillow/blob/10.4.0/setup.py
  - https://pillow.readthedocs.io/en/stable/installation/building-from-source.html#building-from-source

### Explanation of changes:

- Add `PIL._imaging` to `test/imports` to prevent an error `DLL load failed while importing _imaging`


[PKG-5184]: https://anaconda.atlassian.net/browse/PKG-5184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ