### PR TITLE
pillow 11.0.0: rebuild with lcms2 2.16 and libtiff 4.5.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,5 @@
-aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/749c05c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/eb9cc9b
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/822fcae
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/749c05c
+  # - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
+  # - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
+  # - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/04efa45

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 channels:
-  # - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  # - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
-  # - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/04efa45
+  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
+  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/ccc36ef

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
-  - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/2c3b3cb

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/libdeflate-feedstock/pr6/915189e
   - https://staging.continuum.io/prefect/fs/lerc-feedstock/pr3/b5361e3
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr20/af67ffc
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/ccc36ef
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr1/2c3b3cb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     # A subset of one file of tk is also vendored in.
     - freetype {{ freetype }}
     - lcms2 2.16
-    - libtiff {{ libtiff }}
+    - libtiff 4.5.1
     - libwebp-base 1.3.2
     - openjpeg {{ openjpeg }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739
 
 build:
-  number: 0
+  number: 1
   skip: true # [py<39]
 
 requirements:
@@ -30,7 +30,7 @@ requirements:
     # see https://pillow.readthedocs.io/en/latest/installation/building-from-source.html#external-libraries)
     # A subset of one file of tk is also vendored in.
     - freetype {{ freetype }}
-    - lcms2 2.12
+    - lcms2 2.16
     - libtiff {{ libtiff }}
     - libwebp-base 1.3.2
     - openjpeg {{ openjpeg }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     # A subset of one file of tk is also vendored in.
     - freetype {{ freetype }}
     - lcms2 2.16
-    - libtiff 4.5.1
+    - libtiff {{ libtiff }}
     - libwebp-base 1.3.2
     - openjpeg {{ openjpeg }}
   run:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6507](https://anaconda.atlassian.net/browse/PKG-6507)   
- Requirements:
  - https://github.com/python-pillow/Pillow/blob/11.0.0/pyproject.toml
  - https://github.com/python-pillow/Pillow/blob/11.0.0/setup.py
  - https://pillow.readthedocs.io/en/stable/installation/building-from-source.html#building-from-source

### Explanation of changes:

- Pin lcms2 to 2.16 and libtiff to 4.5.1

### Notes

- https://github.com/AnacondaRecipes/libtiff-feedstock/pull/20
- https://github.com/AnacondaRecipes/lcms2-feedstock/pull/1

[PKG-6507]: https://anaconda.atlassian.net/browse/PKG-6507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ