### PR TITLE
pillow 11.1.0: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,6 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b2
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
   - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
   - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,6 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b2
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
+  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
-  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:   # [osx]
     - patches/osx_sdk_path.patch  # [osx]
 build:
-  number: 0
+  number: 1
   skip: true # [py<39]
 
 requirements:
@@ -33,7 +33,7 @@ requirements:
     # A subset of one file of tk is also vendored in.
     - freetype {{ freetype }}
     - lcms2 2.16
-    - libtiff {{ libtiff }}
+    - libtiff 4.7.0
     - libwebp-base 1.3.2
     - openjpeg {{ openjpeg }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - lcms2 2.16
     - libtiff 4.7.0
     - libwebp-base 1.3.2
-    - openjpeg {{ openjpeg }}
+    - openjpeg 2.5.2
   run:
     - python
     - freetype >=2.10.4,<3.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/osx_sdk_path.patch  # [osx]
 build:
   number: 1
-  skip: true # [py<39]
+  skip: true # [py<39 or s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - freetype {{ freetype }}
     - lcms2 2.16
     - libtiff {{ libtiff }}
-    - libwebp-base 1.3.2
+    - libwebp-base {{ libwebp }}
     - openjpeg 2.5.2
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,17 +33,17 @@ requirements:
     # A subset of one file of tk is also vendored in.
     - freetype {{ freetype }}
     - lcms2 2.16
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - libwebp-base 1.3.2
     - openjpeg 2.5.2
   run:
     - python
-    - freetype >=2.10.4,<3.0a0
-    - jpeg >=9e,<10a
-    - libtiff >=4.2.0,<5.0a0
-    - libwebp-base >=1.3.2,<2.0a0
-    - openjpeg >=2.3.0,<3.0a0
-    - zlib >=1.2.13,<1.3.0a0
+    - freetype
+    - jpeg
+    - libtiff
+    - libwebp-base
+    - openjpeg
+    - zlib
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7595](https://anaconda.atlassian.net/browse/PKG-7595) 
- [Upstream repository](https://github.com/python-pillow/Pillow/tree/11.1.0)

### Explanation of changes:

- Bump the build number to 1
- Pin libtiff in host

### Notes:

-

[PKG-7595]: https://anaconda.atlassian.net/browse/PKG-7595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ