### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pybind11
     - setuptools >=77
     # Required by default
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - zlib {{ zlib }}
     # Optional dependencies
     # see https://pillow.readthedocs.io/en/latest/installation/building-from-source.html#external-libraries)
@@ -44,7 +44,7 @@ requirements:
   run:
     - python
     - freetype
-    - jpeg
+    - libjpeg-turbo
     - libtiff
     - libwebp-base
     - libopenjpeg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
 
 requirements:


### PR DESCRIPTION
pillow 12.2.0

**Destination channel:**  defaults

### Links

- [PKG-13233](https://anaconda.atlassian.net/browse/PKG-13233) 
- [Upstream repository](https://github.com/python-pillow/Pillow/blob/12.2.0/pyproject.toml)
### Explanation of changes:
- New build number
- Replace jpeg to libjpeg-turbo


[PKG-13233]: https://anaconda.atlassian.net/browse/PKG-13233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ